### PR TITLE
[usb-gadget]: Use relative symlinks instead of absolute ones

### DIFF
--- a/drivers/usb/gadget/function/configfs.h
+++ b/drivers/usb/gadget/function/configfs.h
@@ -1,1 +1,1 @@
-/home/vishnudasvr07/Development/android_kernel_xiaomi_msm8953/drivers/usb/gadget/configfs.h
+../configfs.h

--- a/drivers/usb/gadget/function/debug.h
+++ b/drivers/usb/gadget/function/debug.h
@@ -1,1 +1,1 @@
-/home/vishnudasvr07/Development/android_kernel_xiaomi_msm8953/drivers/usb/gadget/debug.h
+../debug.h

--- a/drivers/usb/gadget/function/u_f.h
+++ b/drivers/usb/gadget/function/u_f.h
@@ -1,1 +1,1 @@
-/home/vishnudasvr07/Development/android_kernel_xiaomi_msm8953/drivers/usb/gadget/u_f.h
+../u_f.h


### PR DESCRIPTION
This fixes the broken symlink issue, as described [here](https://forum.xda-developers.com/showpost.php?p=74741973&postcount=95).