### PR TITLE
[arm64][arm]: Add msm8953-qrd-sku3-d2.dtb

### DIFF
--- a/arch/arm/boot/.gitignore
+++ b/arch/arm/boot/.gitignore
@@ -4,4 +4,5 @@ xipImage
 bootpImage
 uImage
 *.dtb
+!msm8953-qrd-sku3-d2.dtb
 zImage-dtb

--- a/arch/arm64/boot/dts/.gitignore
+++ b/arch/arm64/boot/dts/.gitignore
@@ -1,1 +1,2 @@
 *.dtb
+!msm8953-qrd-sku3-d2.dtb

--- a/arch/arm64/boot/dts/msm8953-qrd-sku3-d2.dtb
+++ b/arch/arm64/boot/dts/msm8953-qrd-sku3-d2.dtb
@@ -1,0 +1,1 @@
+../../../arm/boot/dts/msm8953-qrd-sku3-d2.dtb


### PR DESCRIPTION
This adds the device tree binary to the repository (instead of depending upon the builder to provide one).

In the future, a dts file can be used instead of adding this binary, but I believe this will work for now.